### PR TITLE
Added offset option

### DIFF
--- a/Release/T-Clock Help.rtf
+++ b/Release/T-Clock Help.rtf
@@ -1,72 +1,341 @@
-{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033\deflangfe1033{\fonttbl{\f0\fswiss\fprq2\fcharset0 Arial;}}
-{\colortbl ;\red0\green0\blue255;}
-{\*\generator Riched20 10.0.16299}{\*\mmathPr\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
-\pard\widctlpar\sa200\sl276\slmult1\qc\b\f0\fs28 T-Clock Advanced Clock Configuration Options\par
-\fs24\par
-Date Options\par
-
-\pard\widctlpar\sa200\sl276\slmult1 Day of Week\b0\fs22\line dddd\tab = Text Weekday Long (by locale/can also use \b aaaa\b0 ) \line ddd\tab = Text Weekday Short (by locale/can also use \b aaa\b0 )\line dde\tab = Abbreviated weekday name in English.\line wi\tab = numeric weekday (ISO) from 1 - 7 (Monday - Sunday)\line wu\tab = numeric weekday (U.S.) from 0 - 6 (Sunday - Saturday)\b\fs24\par
-Day of Month\b0\fs22\line dd\tab = Numeric Day of Month (with leading 0) \line d\tab = Numeric Day of Month\par
-\b\fs24 Month of Year\b0\fs22\line mmmm = Text Month Long (by locale)\line mmm\tab   = Text Month Short (by locale)\line mme\tab   = Abbreviated month name in English.\line mm\tab   = Numeric Month of Year (with leading 0) \line m\tab   = Numeric Month of Year\par
-\b\fs24 Year\b0\fs22\line yyyy\tab = Four Digit Year\line yy\tab = Two Digit Year\line Y\tab = Year by the locale calendar (i.e. the year of the Emperor in Japan)\line ggg\tab = Period/era name by the locale calendar (i.e. \ldblquote Heisei\rdblquote  in Japan) \par
-\b\fs24 Week of Year\b0\fs22\line Wi\tab = ISO 8601 numeric Week-of-Year. (Europe)\line Wu\tab = U.S. like Week-of-Year \endash  beginning on first day of the year, based on sunday\line Ws\tab = numeric Week-of-Year \endash  beginning on first sunday.\line Wm\tab = numeric Week-of-Year \endash  beginning on first monday.\line Ww\tab = SWN (Simple-Week-Number) numeric Week-of-Year. \par
-\b\fs24 Day of Year\b0\fs22\line DOY\tab = Day of Year in decimal format (001 \endash  366).\par
-\b\fs24 Time Zone Name\b0\fs22\line TZN\tab = Name of the machine\rquote s currently configured Time Zone.\line\tab    \b\fs20 Note: \b0 For this to display correctly T-Clock will need to be restarted if Time Zone\line\tab\tab information is changed in Windows Date and Time Properties.\line\tab    \b Note: \b0 doesn't work currently, fixes or suggestions on how to name timezones are\line\tab\tab welcome.\fs22\par
-\par
-
-\pard\widctlpar\sa200\sl276\slmult1\qc\page\b\fs24 Time Options\b0\fs22\par
-
-\pard\widctlpar\sl276\slmult1\b\fs24 Hours\line\b0\fs22 hh\tab = Hour in 12h format with leading 0\line h\tab = Hour in 12h format\line HH\tab = Hour in 24h format with leading 0\line H\tab = Hour in 24h format\line w \'b1 x\tab = Alternate time zone in 12h format \endash  current time \'b1 x given hours\line W \'b1 x\tab = Alternate time zone in 24h format\line\fs24\tab    \b\fs20 Example: \b0 If you are \b UTC -5\b0 , you could enter \b w+05\b0  to get back to the current UTC time.\par
-
-\pard\widctlpar\sa200\sl276\slmult1\tab\tab        If you are \b UTC +2\b0 , you could enter \b w-02\b0  to get back to UTC.\fs22\par
-\b\fs24 Minutes\b0\fs22\line nn\tab = Current Minutes with leading 0\line n\tab = Current Minutes\b\par
-\fs24 Seconds\b0\fs22\line ss\tab = Current Seconds with leading 0\line s\tab = Current Seconds\par
-\b\fs24 AM/PM\b0\fs22\line tt\tab = Add AM/PM Symbol as Configured in T-Clock Time Options (can also use \b am/pm\b0 )\b\par
-\fs24\page\par
-
-\pard\widctlpar\sa200\sl276\slmult1\qc Other Options\par
-\par
-
-\pard\widctlpar\sa200\sl276\slmult1 Swatch Internet Time \b0 a.k.a.\b  .Beat Time\fs22\line\b0 @@@\tab\tab = a decimal time concept introduced in 1998 and marketed by the Swatch corporation as an alternative, decimal measure of time. One of the goals was to simplify the way people in different time zones communicate about time, mostly by eliminating time zones altogether. {{\field{\*\fldinst{HYPERLINK "http://en.wikipedia.org/wiki/Swatch_Internet_Time" }}{\fldrslt{\ul\cf1\cf1\ul Wikipedia: Swatch Internet Time}}}}\b\f0\fs22\line\b0 @@@.@\tab = also with first decimal place\line @@@.@@\tab = and with second decimal place\b\par
-Formatting\line\b0\\n\tab  = Newline Character \endash  Inserts a line break to wrap the output as you like.\line\ldblquote\'85\rdblquote\tab  = To prevent a character from triggering its function encase it in \ldblquote quotes\rdblquote\line LDATE = Use the default system configured Long Date format.\line DATE   = Use the default system configured Short Date format.\line TIME    = Use the default system configured Time format.\line JD\tab = \b Julian Date\b0  - The Julian day is used in the Julian date (JD) system of time\line                measurement for scientific use by the astronomy community. Julian date is\line                recommended for astronomical use by the International Astronomical Union.\line OD\tab = \b Ordinal Date\b0  (YYYY-DDD) - Using UTC/GMT/Zulu Time.\line Od\tab = \b Ordinal Date\b0  (YYYY-DDD) - Using Local Time.\line POSIX = \b Posix/Unix Time\b0  is the Number of Seconds that have elapsed since the\line                Unix Epoch Date: 1970-01-01 00:00:00.\b\par
-\fs24 System Uptime \fs22\line\b0 Sd\tab = Number of Days system has been running.\tab (Not compatible with Sa)\line Sa\tab = Total number of hours system has been running.\tab (Not compatible with Sd)\line Sh\tab = Number of hours system has been running.\tab (Not compatible with Sa)\line Sn\tab = Number of minutes system has been running.\line Ss\tab = Number of seconds system has been running.\line ST\tab = Short uptime displayed in h:mm:ss format.\fs20\line\b\fs18 Note:\b0  this function uses GetTickCount() on OS versions before Vista, so any uptime over 49.7 days will (wrap to 0) be inaccurate. Vista+ supports uptime to infinity though.\fs20\line\b\fs18 Note\'b2:\b0  this format additionally supports advanced padding. "S__a" will pad with up to two spaces in case "hours" are less than 100. "S___dd" will pad with up to three spaces and additionally got a zero padded minimum size of two. eg. "   03" for a three hour uptime.\fs22\par
-\page\par
-
-\pard\widctlpar\sa200\sl276\slmult1\qc\b\fs24 T-Clock Command Line Options\par
-
-\pard\widctlpar\qc\b0\fs22\lang1031\par
-
-\pard\widctlpar   \tab\b /exit\tab\tab : \b0 exit T-Clock\par
-  \tab\b /prop\tab\tab : \b0 open T-Clock's properties (options)\par
-  \tab\b /start\tab\tab : \b0 start Stopwatch (open as/if needed)\par
-  \tab\b /stop\tab\tab : \b0 stop the Stopwatch counter (kind of pause)\par
-  \tab\b /reset\tab\tab : \b0 reset Stopwatch to 0 (doesn't stop)\par
-  \tab\b /lap\tab\tab : \b0 record a (the current) Lap Time\par
-  \tab\b /sync\tab\tab : \b0 synchronize the time (UAC elevation required)\par
-  \tab\b /syncopt\tab : \b0 open SNTP / synchronize options, also allows to sync now\par
-  \tab\b /exit-explorer\tab : \b0 tries to exit Explorer gracefully (kills after 15 sec)\par
-  \tab\b /restart-explorer : \b0 like above, but starts it afterwards\par
-  \tab\b /SEH /exit\tab : \b0 unloads "exchndl" exception handler and exits\par
-
-\pard\widctlpar\sa200\sl276\slmult1\b\lang1033\par
-\b0\par
-
-\pard\widctlpar\sa200\sl276\slmult1\qc\b\fs24 T-Clock Hotkeys\fs22\par
-
-\pard\widctlpar\sa200\sl276\slmult1\b0 T-Clock Includes User Configurable Hotkeys to: \line Open the Stopwatch.\line Open Add/Edit Timers.\line Open Properties Dialog.\line Display T-Clock Calendar.\line Open Timer Watch Window.\line\b\fs18 Note: \b0 Timer Watch will auto-close if it isn\rquote t needed (has no timers being watched).\fs22\par
-\page\par
-
-\pard\widctlpar\sa200\sl276\slmult1\qc\b\fs24 How to Use the PC Beep (.pcb) Sound Files\line\b0\fs22 For Those Without Sound Cards\b\par
-
-\pard\widctlpar\sa200\sl276\slmult1\b0\par
-
-\pard\widctlpar\sa200\sl276\slmult1\qj    For those that do not have sound (or just like these tones) T-Clock includes the option to use .pcb files to play a series of tones through the PC\rquote s system speaker. The .pcb files are in a plain text format, and have a straight forward (duration, frequency) simple syntax. So they can be created or edited with any plain text editor (like Notepad).\par
-
-\pard\widctlpar\sa200\sl276\slmult1    There is one demo.pcb file included in the Waves directory. Content of the file with line by line explanation is below: \par
-
-\pard\widctlpar\li720\sa200\sl276\slmult1\fs20 100, 400\tab Creates 100ms long 400Hz tone.\line 100, -1\tab\tab 100ms Pause between tones.\line 100, 500 \tab Creates 100ms long 500Hz tone.\line 100, -1\tab\tab 100ms Pause between tones.\line 100, 600 \tab Creates 100ms long 600Hz tone.\line 100, -1\tab\tab 100ms Pause between tones.\line 100, 500 \tab Creates 100ms long 500Hz tone.\line 100, -1\tab\tab 100ms Pause between tones.\line 100, 400 \tab Creates 100ms long 400Hz tone.\line\fs22 500, -1\tab\tab 500ms Pause at end of file for smoother looping.\par
-
-\pard\widctlpar\sa200\sl276\slmult1    The first number (duration) is in milliseconds. It controls how long the tone or pause will be.\par
-   The second number (frequency) is in hertz, and controls the pitch of the tone being played. Valid values are from 37 to 32767.\par
-}
- 
+{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff31507\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi31507\deflang16393\deflangfe16393\themelang16393\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f1\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604020202020204}Arial;}
+{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria Math;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}
+{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
+{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f43\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f44\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f46\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f47\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f48\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f49\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f50\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f51\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f53\fbidi \fswiss\fcharset238\fprq2 Arial CE;}{\f54\fbidi \fswiss\fcharset204\fprq2 Arial Cyr;}
+{\f56\fbidi \fswiss\fcharset161\fprq2 Arial Greek;}{\f57\fbidi \fswiss\fcharset162\fprq2 Arial Tur;}{\f58\fbidi \fswiss\fcharset177\fprq2 Arial (Hebrew);}{\f59\fbidi \fswiss\fcharset178\fprq2 Arial (Arabic);}
+{\f60\fbidi \fswiss\fcharset186\fprq2 Arial Baltic;}{\f61\fbidi \fswiss\fcharset163\fprq2 Arial (Vietnamese);}{\f383\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f384\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
+{\f386\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f387\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f390\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f391\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
+{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
+{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Calibri Light CE;}{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Calibri Light Cyr;}
+{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Calibri Light Greek;}{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Calibri Light Tur;}{\fhimajor\f31533\fbidi \fswiss\fcharset177\fprq2 Calibri Light (Hebrew);}
+{\fhimajor\f31534\fbidi \fswiss\fcharset178\fprq2 Calibri Light (Arabic);}{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Calibri Light Baltic;}{\fhimajor\f31536\fbidi \fswiss\fcharset163\fprq2 Calibri Light (Vietnamese);}
+{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
+{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbminor\f31558\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbminor\f31559\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\fdbminor\f31561\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
+{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
+{\fhiminor\f31573\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\fhiminor\f31574\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}
+{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
+{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
+\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap 
+\ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 
+\af31507\afs22\alang1025 \ltrch\fcs0 \fs22\lang16393\langfe16393\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp16393\langfenp16393 \snext0 \sqformat \spriority0 Normal;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}
+{\*\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa160\sl259\slmult1
+\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs22\alang1025 \ltrch\fcs0 \fs22\lang16393\langfe16393\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp16393\langfenp16393 
+\snext11 \ssemihidden \sunhideused Normal Table;}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid983163\rsid1322939\rsid4078668\rsid11488632\rsid14639109}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
+\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Maninder Suri}{\creatim\yr2018\mo6\dy9\hr14\min39}{\revtim\yr2018\mo6\dy9\hr16\min9}{\version2}{\edmins90}{\nofpages7}{\nofwords1053}{\nofchars6005}
+{\nofcharsws7044}{\vern59}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale120\rsidroot983163 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
+\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
+\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang 
+{\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\qc \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs22\alang1025 \ltrch\fcs0 
+\fs22\lang16393\langfe16393\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp16393\langfenp16393 {\rtlch\fcs1 \ab\af1\afs28 \ltrch\fcs0 \b\f1\fs28\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 T-Clock Advanced Clock Configuration Options
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 
+\par \hich\af1\dbch\af31505\loch\f1 Date Options
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Day of Week}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\line \hich\af1\dbch\af31505\loch\f1 dddd\tab = Text Weekday Long (by locale/can also use }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 aaaa}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\hich\af1\dbch\af31505\loch\f1 ) \line ddd\tab = Text Weekday Short (by locale/can also use }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 aaa}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\hich\af1\dbch\af31505\loch\f1 )\line dde\tab = Abbreviated weekday name in English.\line wi\tab = numeric weekday (ISO) from \hich\af1\dbch\af31505\loch\f1 1 - 7 (Monday - Sunday)\line wu\tab = numeric weekday (U.S.) from 0 - 6 (Sunday - Saturday)}{
+\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 
+\par \hich\af1\dbch\af31505\loch\f1 Day of Month}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 dd\tab = Numeric Day of Month (with leading 0) \line d\tab = Numeric Day of Month
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Month of Year}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 mmmm = Text Month Long (by locale)\line mmm\tab 
+  = Text Month Short (by locale)\line mme\tab  \hich\af1\dbch\af31505\loch\f1  = Abbreviated month name in English.\line mm\tab   = Numeric Month of Year (with leading 0) \line m\tab   = Numeric Month of Year
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Year}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 yyyy\tab = Four Digit Year\line yy\tab = Two Digit Year\line Y
+\tab = Year by the locale calendar (i.e. the year of the Emperor in Japan)\line ggg\tab = Period/era name b\hich\af1\dbch\af31505\loch\f1 \hich\f1 y the locale calendar (i.e. \'93\loch\f1 \hich\f1 Heisei\'94\loch\f1  in Japan) 
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Week of Year}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 Wi\tab = ISO 8601 numeric Week-of-Year. (Europe)\line Wu
+\tab = U.S. like Week-of-Year \hich\f1 \endash \loch\f1  beginning on first day of the year, based on sunday\line Ws\tab = numeric Week-of-Year \hich\f1 \endash \loch\f1  beginning on first sunday.\line Wm\tab = numeric \hich\af1\dbch\af31505\loch\f1 
+Week-of-Year \hich\f1 \endash \loch\f1  beginning on first monday.\line Ww\tab = SWN (Simple-Week-Number) numeric Week-of-Year. 
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Day of Year}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 DOY\tab = Day of Year in decimal format (001 \hich\f1 
+\endash \loch\f1  366).
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Time Zone Name}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 TZN\tab = Name of the machine\hich\f1 \rquote \loch\f1 
+s currently configured Time Zone.\line \tab    }{\rtlch\fcs1 \ab\af1\afs20 \ltrch\fcs0 \b\f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Note: }{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 
+For this to dis\hich\af1\dbch\af31505\loch\f1 play correctly T-Clock will need to be restarted if Time Zone\line \tab \tab information is changed in Windows Date and Time Properties.\line \tab    }{\rtlch\fcs1 \ab\af1\afs20 \ltrch\fcs0 
+\b\f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Note: }{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 doesn't work currently, fixes or suggestions on how to name timezones are\line \tab \tab welcome.}
+{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\par 
+\par }\pard \ltrpar\qc \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \page }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 
+Time Options}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\par }\pard \ltrpar\ql \li0\ri0\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Hours\line }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\hich\af1\dbch\af31505\loch\f1 hh\tab = Hour in 12h\hich\af1\dbch\af31505\loch\f1  format with leading 0\line h\tab = Hour in 12h format\line HH\tab = Hour in 24h format with leading 0\line H\tab = Hour in 24h format\line \hich\f1 w \'b1\loch\f1  x\tab 
+= Alternate time zone in 12h format \hich\f1 \endash \loch\f1 \hich\f1  current time \'b1\loch\f1  x given hours\line \hich\f1 W \'b1\loch\f1  x\tab = Alternate time zone in 24h format\line }{\rtlch\fcs1 \af1\afs24 \ltrch\fcs0 \f1\fs24\insrsid14639109 
+\tab \hich\af1\dbch\af31505\loch\f1    }{\rtlch\fcs1 \ab\af1\afs20 \ltrch\fcs0 \b\f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Example: }{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 If you are }{
+\rtlch\fcs1 \ab\af1\afs20 \ltrch\fcs0 \b\f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 UTC -5}{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 , y\hich\af1\dbch\af31505\loch\f1 ou could enter }{
+\rtlch\fcs1 \ab\af1\afs20 \ltrch\fcs0 \b\f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 w+05}{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1  to get back to the current UTC time.
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \tab \tab \hich\af1\dbch\af31505\loch\f1        If you are }{\rtlch\fcs1 \ab\af1\afs20 \ltrch\fcs0 
+\b\f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 UTC +2}{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 , you could enter }{\rtlch\fcs1 \ab\af1\afs20 \ltrch\fcs0 \b\f1\fs20\insrsid14639109 
+\hich\af1\dbch\af31505\loch\f1 w-02}{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \hich\af1\dbch\af31505\loch\f1  to get back to UTC.}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Minutes}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 nn\tab = Current Minutes with leading 0\line n\tab 
+= Current Minutes}{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Seconds}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 ss\tab = Current Seconds with leading 0\line s\tab 
+= Current Seconds
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 AM\hich\af1\dbch\af31505\loch\f1 /PM}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 tt\tab 
+= Add AM/PM Symbol as Configured in T-Clock Time Options (can also use }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 am/pm}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 )}{
+\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \page 
+\par }\pard \ltrpar\qc \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Other Options
+\par 
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid983163 \hich\af1\dbch\af31505\loch\f1 Date / Time Offset
+\par }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid983163 \hich\af1\dbch\af31505\loch\f1 \hich\f1 o \'b1\loch\f1  x\tab \hich\f1 = Changes the current time \'b1\loch\f1  x given minutes. \line 
+Can be used to display multiple timezone information with full support of other Fo\hich\af1\dbch\af31505\loch\f1 rmatting options. Anytime the format encounters \hich\f1 \lquote \loch\f1 \hich\f1 o \'b1\loch\f1  x\hich\f1 \rquote \loch\f1  pattern, }{
+\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid11488632 \hich\af1\dbch\af31505\loch\f1 the succeeding format pattern works on the offset time.\line \line 
+For example, if your system is set for India Standard Time, and you want to also see the time for Central Standard Time (10h 30m = 630\hich\af1\dbch\af31505\loch\f1 m behind IST), you can specify\line }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\insrsid11488632\charrsid11488632 \hich\af1\dbch\af31505\loch\f1 "IST}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid11488632 \hich\af1\dbch\af31505\loch\f1 :}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid11488632\charrsid11488632 \hich\af1\dbch\af31505\loch\f1 "
+}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid11488632 \hich\af1\dbch\af31505\loch\f1  }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid11488632\charrsid11488632 \hich\af1\dbch\af31505\loch\f1 hh:nn:ss tt "CST}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid11488632 
+\hich\af1\dbch\af31505\loch\f1 :}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid11488632\charrsid11488632 \hich\af1\dbch\af31505\loch\f1 "}{\rtlch\fcs1 \af1 \ltrch\fcs0 \b\f1\insrsid11488632\charrsid11488632 \hich\af1\dbch\af31505\loch\f1 o-630}{\rtlch\fcs1 
+\af1 \ltrch\fcs0 \f1\insrsid11488632\charrsid11488632 \hich\af1\dbch\af31505\loch\f1 hh:nn:ss tt}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid11488632 \line \hich\af1\dbch\af31505\loch\f1 anything after the \hich\f1 \lquote \loch\f1 o-630\hich\f1 \rquote 
+\loch\f1  will use the offset time to be displayed}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid4078668 .\line }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \line \hich\af1\dbch\af31505\loch\f1 
+We can have multiple offsets to show more timezones. Note that we will need to calculate the offset from the last\hich\af1\dbch\af31505\loch\f1  offset time.}{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid983163 
+\par 
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Swatch Internet Time }{\rtlch\fcs1 \af1\afs24 \ltrch\fcs0 \f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 a.k.a.}{\rtlch\fcs1 \ab\af1\afs24 
+\ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1  .Beat Time}{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 \line }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 @@@\tab \tab 
+= a decimal time concept introd\hich\af1\dbch\af31505\loch\f1 
+uced in 1998 and marketed by the Swatch corporation as an alternative, decimal measure of time. One of the goals was to simplify the way people in different time zones communicate about time, mostly by eliminating time zones altogether. }
+{\field{\*\fldinst {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 HYPERLINK "http://\hich\af1\dbch\af31505\loch\f1 en.wikipedia.org/wiki/Swatch_Internet_Time" }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid983163 
+{\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c00000068007400740070003a002f002f0065006e002e00770069006b006900700065006400690061002e006f00720067002f00770069006b0069002f005300770061007400630068005f0049006e00740065007200
+6e00650074005f00540069006d0065000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\ul\cf2\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Wikipedia: Swatch Internet Time}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 \line }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 @@@.@\tab = also with first decimal place\line @@@.@@\tab 
+= and with second decimal place}{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 
+\par \hich\af1\dbch\af31505\loch\f1 Formatting\line }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \\\hich\af1\dbch\af31505\loch\f1 n\tab  = Newline Character \hich\f1 \endash \loch\f1  Inserts a line break to wrap the output as you like.\line \hich\f1 
+\'93\'85\'94\tab \loch\f1  = To \hich\af1\dbch\af31505\loch\f1 \hich\f1 prevent a character from triggering its function encase it in \'93\loch\f1 \hich\f1 quotes\'94\line \loch\f1 LDATE = Use the default system configured Long Date format.\line 
+DATE   = Use the default system configured Short Date format.\line TIME    = Use the default system configured Time format.\line JD\tab = }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 J
+\hich\af1\dbch\af31505\loch\f1 ulian Date}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1  - The Julian day is used in the Julian date (JD) system of time\line 
+               measurement for scientific use by the astronomy community. Julian date is\line                recommended for astronomical use by the International Astronomical Union.\line OD\tab \hich\af1\dbch\af31505\loch\f1 = }{\rtlch\fcs1 \ab\af1 
+\ltrch\fcs0 \b\f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Ordinal Date}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1  (YYYY-DDD) - Using UTC/GMT/Zulu Time.\line Od\tab = }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 
+\b\f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Ordinal Date}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1  (YYYY-DDD) - Using Local Time.\line POSIX = }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 
+\hich\af1\dbch\af31505\loch\f1 Posix/Unix Time}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 \hich\af1\dbch\af31505\loch\f1  is the Number of Seconds that have elapsed since the\line                Unix Epoch Date: 1970-01-01 00:00:00.}{\rtlch\fcs1 
+\ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 
+\par }{\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 System Uptime }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\insrsid14639109 \line }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\hich\af1\dbch\af31505\loch\f1 Sd\tab = Numb\hich\af1\dbch\af31505\loch\f1 er of Days system has been running.\tab (Not compatible with Sa)\line Sa\tab = Total number of hours system has been running.\tab (Not compatible with Sd)\line Sh\tab 
+= Number of hours system has been running.\tab (Not compatible with Sa)\line Sn\tab = Number of minutes system has been running.\line \hich\af1\dbch\af31505\loch\f1 Ss\tab = Number of seconds system has been running.\line ST\tab 
+= Short uptime displayed in h:mm:ss format.}{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \line }{\rtlch\fcs1 \ab\af1\afs18 \ltrch\fcs0 \b\f1\fs18\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Note:}{\rtlch\fcs1 \af1\afs18 \ltrch\fcs0 
+\f1\fs18\insrsid14639109 \hich\af1\dbch\af31505\loch\f1  this function uses GetTickCount() on OS versions before Vista, so any uptime over 49.7 days will (wrap to 0) be inaccurate. Vista+ supports uptime to infi\hich\af1\dbch\af31505\loch\f1 nity though.}
+{\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\insrsid14639109 \line }{\rtlch\fcs1 \ab\af1\afs18 \ltrch\fcs0 \b\f1\fs18\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 \hich\f1 Note\'b2\loch\f1 :}{\rtlch\fcs1 \af1\afs18 \ltrch\fcs0 \f1\fs18\insrsid14639109 
+\hich\af1\dbch\af31505\loch\f1 
+ this format additionally supports advanced padding. "S__a" will pad with up to two spaces in case "hours" are less than 100. "S___dd" will pad with up to three spaces and additionally got a zero padded minimum size of two. eg. "   03" f
+\hich\af1\dbch\af31505\loch\f1 or a three hour uptime.}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\insrsid14639109 
+\par \page 
+\par }\pard \ltrpar\qc \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 T-Clock Command Line Options
+\par }\pard \ltrpar\qc \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1031\langfe16393\langnp1031\insrsid14639109 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 
+\b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /exit\tab \tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 exit T-Clock
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /prop\tab \tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 open T-Clock's properties (options)
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /start\tab \tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 start Stopwatch (open as/if needed)
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /stop\tab \tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 stop the Stopwatch counter (kind of pause)
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /reset\tab \tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 reset Stop\hich\af1\dbch\af31505\loch\f1 watch to 0 (doesn't stop)
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /lap\tab \tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 record a (the current) Lap Time
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /sync\tab \tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 synchronize the time (UAC elevation required)
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /syncopt\tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1031\langfe16393\langnp1031\insrsid14639109 
+\hich\af1\dbch\af31505\loch\f1 open SNTP / synchronize options, also allows to sync now
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /exit-explorer\tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 tries to exit Explorer gracefully (kil\hich\af1\dbch\af31505\loch\f1 ls after 15 sec)
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /restart-explorer : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 like above, but starts it afterwards
+\par \hich\af1\dbch\af31505\loch\f1   \tab }{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 /SEH /exit\tab : }{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\f1\lang1031\langfe16393\langnp1031\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 unloads "exchndl" exception handler and exits
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af1 \ltrch\fcs0 \b\f1\lang1033\langfe16393\langnp1033\insrsid14639109 
+\par }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 
+\par }\pard \ltrpar\qc \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 T-Clock Hotkeys}{\rtlch\fcs1 
+\ab\af1 \ltrch\fcs0 \b\f1\lang1033\langfe16393\langnp1033\insrsid14639109 
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 T-Clock Includes User Configurable Hotkeys to: 
+\line Open the Stopwatch.\line Open Add/Edit Timers.\line Open Prop\hich\af1\dbch\af31505\loch\f1 erties Dialog.\line Display T-Clock Calendar.\line Open Timer Watch Window.\line }{\rtlch\fcs1 \ab\af1\afs18 \ltrch\fcs0 
+\b\f1\fs18\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 Note: }{\rtlch\fcs1 \af1\afs18 \ltrch\fcs0 \f1\fs18\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 
+Timer Watch will auto-close if it isn\hich\f1 \rquote \loch\f1 t needed (has no timers being watched).}{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 
+\par \page 
+\par }\pard \ltrpar\qc \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af1\afs24 \ltrch\fcs0 \b\f1\fs24\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 
+How to Use the PC Beep (.pcb) Sound Files\line }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 For Those Without Sound Cards}{\rtlch\fcs1 \ab\af1 \ltrch\fcs0 
+\b\f1\lang1033\langfe16393\langnp1033\insrsid14639109 
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 
+\par }\pard \ltrpar\qj \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1    For those that do not have s
+\hich\af1\dbch\af31505\loch\f1 ound (or just like these tones) T-Clock includes the option to use .pcb files to play a series of tones through the PC\hich\f1 \rquote \loch\f1 
+s system speaker. The .pcb files are in a plain text format, and have a straight forward (duration, frequency) simple syntax. So they ca\hich\af1\dbch\af31505\loch\f1 n\hich\af1\dbch\af31505\loch\f1 
+ be created or edited with any plain text editor (like Notepad).
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 
+   There is one demo.pcb file included in the Waves directory. Content of the file with line by line explanation is below: 
+\par }\pard \ltrpar\ql \li720\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin720\itap0 {\rtlch\fcs1 \af1\afs20 \ltrch\fcs0 \f1\fs20\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 100, 400\tab 
+Creates 100ms long 400Hz tone.\line 100, -1\tab \tab 100ms Pause betwee\hich\af1\dbch\af31505\loch\f1 n tones.\line 100, 500 \tab Creates 100ms long 500Hz tone.\line 100, -1\tab \tab 100ms Pause between tones.\line 100, 600 \tab 
+Creates 100ms long 600Hz tone.\line 100, -1\tab \tab 100ms Pause between tones.\line 100, 500 \tab Creates 100ms long 500Hz tone.\line 100, -1\tab \tab 100ms Pause between tones.\line 100, 400 \tab Creat\hich\af1\dbch\af31505\loch\f1 e
+\hich\af1\dbch\af31505\loch\f1 s 100ms long 400Hz tone.\line }{\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 500, -1\tab \tab 500ms Pause at end of file for smoother looping.
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\lang1033\langfe16393\langnp1033\insrsid14639109 \hich\af1\dbch\af31505\loch\f1 
+   The first number (duration) is in milliseconds. It controls how long the tone or pause will be.
+\par \hich\af1\dbch\af31505\loch\f1    The second number (frequency) is in hertz, and controls the pitch of th\hich\af1\dbch\af31505\loch\f1 e tone being played. Valid values are from 37 to 32767.
+\par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
+9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
+5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
+b01d583deee5f99824e290b4ba3f364eac4a430883b3c092d4eca8f946c916422ecab927f52ea42b89a1cd59c254f919b0e85e6535d135a8de20f20b8c12c3b0
+0c895fcf6720192de6bf3b9e89ecdbd6596cbcdd8eb28e7c365ecc4ec1ff1460f53fe813d3cc7f5b7f020000ffff0300504b030414000600080000002100a5d6
+a7e7c0000000360100000b0000005f72656c732f2e72656c73848fcf6ac3300c87ef85bd83d17d51d2c31825762fa590432fa37d00e1287f68221bdb1bebdb4f
+c7060abb0884a4eff7a93dfeae8bf9e194e720169aaa06c3e2433fcb68e1763dbf7f82c985a4a725085b787086a37bdbb55fbc50d1a33ccd311ba548b6309512
+0f88d94fbc52ae4264d1c910d24a45db3462247fa791715fd71f989e19e0364cd3f51652d73760ae8fa8c9ffb3c330cc9e4fc17faf2ce545046e37944c69e462
+a1a82fe353bd90a865aad41ed0b5b8f9d6fd010000ffff0300504b0304140006000800000021006b799616830000008a0000001c0000007468656d652f746865
+6d652f7468656d654d616e616765722e786d6c0ccc4d0ac3201040e17da17790d93763bb284562b2cbaebbf600439c1a41c7a0d29fdbd7e5e38337cedf14d59b
+4b0d592c9c070d8a65cd2e88b7f07c2ca71ba8da481cc52c6ce1c715e6e97818c9b48d13df49c873517d23d59085adb5dd20d6b52bd521ef2cdd5eb9246a3d8b
+4757e8d3f729e245eb2b260a0238fd010000ffff0300504b030414000600080000002100b6f4679893070000c9200000160000007468656d652f7468656d652f
+7468656d65312e786d6cec59cd8b1bc915bf07f23f347d97f5d5ad8fc1f2a24fcfda33b6b164873dd648a5eef2547789aad28cc56208de532e81c026e49085bd
+ed21842cecc22eb9e48f31d8249b3f22afaa5bdd5552c99e191c3061463074977eefd5afde7bf5de53d5ddcf5e26d4bbc05c1096f6fcfa9d9aefe174ce16248d
+7afeb3d9a4d2f13d2151ba4094a5b8e76fb0f03fbbf7eb5fdd454732c609f6403e1547a8e7c752ae8eaa5531876124eeb0154ee1bb25e30992f0caa3ea82a34b
+d09bd06aa3566b55134452df4b51026a1f2f97648ebd9952e9dfdb2a1f53784da5500373caa74a35b6243476715e5708b11143cabd0b447b3eccb3609733fc52
+fa1e4542c2173dbfa6fffceabdbb5574940b517940d6909be8bf5c2e17589c37f49c3c3a2b260d823068f50bfd1a40e53e6edc1eb7c6ad429f06a0f91c569a71
+b175b61bc320c71aa0ecd1a17bd41e35eb16ded0dfdce3dc0fd5c7c26b50a63fd8c34f2643b0a285d7a00c1feee1c3417730b2f56b50866fede1dbb5fe28685b
+fa3528a6243ddf43d7c25673b85d6d0159327aec8477c360d26ee4ca4b144443115d6a8a254be5a1584bd00bc6270050408a24493db959e1259a43140f112567
+9c7827248a21f056286502866b8ddaa4d684ffea13e827ed5174849121ad780113b137a4f87862cec94af6fc07a0d537206f7ffef9cdeb1fdfbcfee9cd575fbd
+79fdf77c6eadca923b466964cafdf2dd1ffef3cd6fbd7ffff0ed2f5fff319b7a172f4cfcbbbffdeedd3ffef93ef5b0e2d2146ffff4fdbb1fbf7ffbe7dfffebaf
+5f3bb4f7393a33e1339260e13dc297de5396c0021dfcf119bf9ec42c46c494e8a791402952b338f48f656ca11f6d10450edc00db767cce21d5b880f7d72f2cc2
+d398af2571687c182716f094313a60dc6985876a2ec3ccb3751ab927e76b13f714a10bd7dc43945a5e1eaf579063894be530c616cd2714a5124538c5d253dfb1
+738c1dabfb8210cbaea764ce99604be97d41bc01224e93ccc899154da5d03149c02f1b1741f0b7659bd3e7de8051d7aa47f8c246c2de40d4417e86a965c6fb68
+2d51e252394309350d7e8264ec2239ddf0b9891b0b099e8e3065de78818570c93ce6b05ec3e90f21cdb8dd7e4a37898de4929cbb749e20c64ce4889d0f6394ac
+5cd829496313fbb938871045de13265df05366ef10f50e7e40e941773f27d872f787b3c133c8b026a53240d4376beef0e57dccacf89d6ee8126157aae9f3c44a
+b17d4e9cd131584756689f604cd1255a60ec3dfbdcc160c05696cd4bd20f62c82ac7d815580f901dabea3dc5027a25d5dcece7c91322ac909de2881de073bad9
+493c1b9426881fd2fc08bc6eda7c0ca52e7105c0633a3f37818f08f480102f4ea33c16a0c308ee835a9fc4c82a60ea5db8e375c32dff5d658fc1be7c61d1b8c2
+be04197c6d1948eca6cc7b6d3343d49aa00c9819822ec3956e41c4727f29a28aab165b3be596f6a62ddd00dd91d5f42424fd6007b4d3fb84ffbbde073a8cb77f
+f9c6b10f3e4ebfe3566c25ab6b763a8792c9f14e7f7308b7dbd50c195f904fbfa919a175fa04431dd9cf58b73dcd6d4fe3ffdff73487f6f36d2773a8dfb8ed64
+7ce8306e3b99fc70e5e3743265f3027d8d3af0c80e7af4b14f72f0d46749289dca0dc527421ffc08f83db398c0a092d3279eb838055cc5f0a8ca1c4c60e1228e
+b48cc799fc0d91f134462b381daafb4a492472d591f0564cc0a1911e76ea5678ba4e4ed9223becacd7d5c16656590592e5782d2cc6e1a04a66e856bb3cc02bd4
+6bb6913e68dd1250b2d721614c6693683a48b4b783ca48fa58178ce620a157f65158741d2c3a4afdd6557b2c805ae115f8c1edc1cff49e1f06200242701e07cd
+f942f92973f5d6bbda991fd3d3878c69450034d8db08283ddd555c0f2e4fad2e0bb52b78da2261849b4d425b46377822869fc17974aad1abd0b8aeafbba54b2d
+7aca147a3e08ad9246bbf33e1637f535c8ede6069a9a9982a6de65cf6f35430899395af5fc251c1ac363b282d811ea3717a211dcbccc25cf36fc4d32cb8a0b39
+4222ce0cae934e960d122231f728497abe5a7ee1069aea1ca2b9d51b90103e59725d482b9f1a3970baed64bc5ce2b934dd6e8c284b67af90e1b35ce1fc568bdf
+1cac24d91adc3d8d1797de195df3a708422c6cd795011744c0dd413db3e682c0655891c8caf8db294c79da356fa3740c65e388ae62945714339967709dca0b3a
+faadb081f196af190c6a98242f8467912ab0a651ad6a5a548d8cc3c1aafb6121653923699635d3ca2aaa6abab39835c3b60cecd8f26645de60b53531e434b3c2
+67a97b37e576b7b96ea74f28aa0418bcb09fa3ea5ea12018d4cac92c6a8af17e1a56393b1fb56bc776811fa07695226164fdd656ed8edd8a1ae19c0e066f54f9
+416e376a6168b9ed2bb5a5f5adb979b1cdce5e40f2184197bba6526857c2c92e47d0104d754f92a50dd8222f65be35e0c95b73d2f3bfac85fd60d80887955a27
+1c57826650ab74c27eb3d20fc3667d1cd66ba341e31514161927f530bbb19fc00506dde4f7f67a7cefee3ed9ded1dc99b3a4caf4dd7c5513d777f7f5c6e1bb7b
+8f40d2f9b2d598749bdd41abd26df627956034e854bac3d6a0326a0ddba3c9681876ba9357be77a1c141bf390c5ae34ea5551f0e2b41aba6e877ba9576d068f4
+8376bf330efaaff23606569ea58fdc16605ecdebde7f010000ffff0300504b0304140006000800000021000dd1909fb60000001b010000270000007468656d65
+2f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72656c73848f4d0ac2301484f78277086f6fd3ba109126dd88d0add40384e4350d36
+3f2451eced0dae2c082e8761be9969bb979dc9136332de3168aa1a083ae995719ac16db8ec8e4052164e89d93b64b060828e6f37ed1567914b284d262452282e
+3198720e274a939cd08a54f980ae38a38f56e422a3a641c8bbd048f7757da0f19b017cc524bd62107bd5001996509affb3fd381a89672f1f165dfe514173d985
+0528a2c6cce0239baa4c04ca5bbabac4df000000ffff0300504b01022d0014000600080000002100e9de0fbfff0000001c020000130000000000000000000000
+0000000000005b436f6e74656e745f54797065735d2e786d6c504b01022d0014000600080000002100a5d6a7e7c0000000360100000b00000000000000000000
+000000300100005f72656c732f2e72656c73504b01022d00140006000800000021006b799616830000008a0000001c0000000000000000000000000019020000
+7468656d652f7468656d652f7468656d654d616e616765722e786d6c504b01022d0014000600080000002100b6f4679893070000c92000001600000000000000
+000000000000d60200007468656d652f7468656d652f7468656d65312e786d6c504b01022d00140006000800000021000dd1909fb60000001b01000027000000
+000000000000000000009d0a00007468656d652f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72656c73504b050600000000050005005d010000980b00000000}
+{\*\colorschememapping 3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d22796573223f3e0d0a3c613a636c724d
+617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
+6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
+656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
+{\*\latentstyles\lsdstimax375\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 1;
+\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 2;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;
+\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;
+\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 1;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 5;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 8;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 9;
+\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 4;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 5;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 6;
+\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 7;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 8;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 9;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal Indent;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footnote text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 header;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footer;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index heading;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority35 \lsdlocked0 caption;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 table of figures;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 envelope address;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 envelope return;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footnote reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation reference;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 line number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 page number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 endnote reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 endnote text;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 table of authorities;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 macro;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 toa heading;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 5;\lsdqformat1 \lsdpriority10 \lsdlocked0 Title;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Closing;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Signature;\lsdsemihidden1 \lsdunhideused1 \lsdpriority1 \lsdlocked0 Default Paragraph Font;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 4;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Message Header;\lsdqformat1 \lsdpriority11 \lsdlocked0 Subtitle;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Salutation;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Date;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text First Indent;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text First Indent 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Note Heading;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Block Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 FollowedHyperlink;\lsdqformat1 \lsdpriority22 \lsdlocked0 Strong;
+\lsdqformat1 \lsdpriority20 \lsdlocked0 Emphasis;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Document Map;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Plain Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 E-mail Signature;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Top of Form;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Bottom of Form;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal (Web);\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Acronym;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Address;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Cite;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Code;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Definition;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Keyboard;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Preformatted;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Sample;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Typewriter;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Variable;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal Table;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation subject;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 No List;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 1;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 6;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 8;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 6;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 8;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Contemporary;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Elegant;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Professional;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Subtle 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Subtle 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Balloon Text;\lsdpriority39 \lsdlocked0 Table Grid;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Theme;\lsdsemihidden1 \lsdlocked0 Placeholder Text;
+\lsdqformat1 \lsdpriority1 \lsdlocked0 No Spacing;\lsdpriority60 \lsdlocked0 Light Shading;\lsdpriority61 \lsdlocked0 Light List;\lsdpriority62 \lsdlocked0 Light Grid;\lsdpriority63 \lsdlocked0 Medium Shading 1;\lsdpriority64 \lsdlocked0 Medium Shading 2;
+\lsdpriority65 \lsdlocked0 Medium List 1;\lsdpriority66 \lsdlocked0 Medium List 2;\lsdpriority67 \lsdlocked0 Medium Grid 1;\lsdpriority68 \lsdlocked0 Medium Grid 2;\lsdpriority69 \lsdlocked0 Medium Grid 3;\lsdpriority70 \lsdlocked0 Dark List;
+\lsdpriority71 \lsdlocked0 Colorful Shading;\lsdpriority72 \lsdlocked0 Colorful List;\lsdpriority73 \lsdlocked0 Colorful Grid;\lsdpriority60 \lsdlocked0 Light Shading Accent 1;\lsdpriority61 \lsdlocked0 Light List Accent 1;
+\lsdpriority62 \lsdlocked0 Light Grid Accent 1;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 1;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 1;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 1;\lsdsemihidden1 \lsdlocked0 Revision;
+\lsdqformat1 \lsdpriority34 \lsdlocked0 List Paragraph;\lsdqformat1 \lsdpriority29 \lsdlocked0 Quote;\lsdqformat1 \lsdpriority30 \lsdlocked0 Intense Quote;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 1;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 1;
+\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 1;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 1;\lsdpriority70 \lsdlocked0 Dark List Accent 1;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 1;\lsdpriority72 \lsdlocked0 Colorful List Accent 1;
+\lsdpriority73 \lsdlocked0 Colorful Grid Accent 1;\lsdpriority60 \lsdlocked0 Light Shading Accent 2;\lsdpriority61 \lsdlocked0 Light List Accent 2;\lsdpriority62 \lsdlocked0 Light Grid Accent 2;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 2;
+\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 2;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 2;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 2;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 2;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 2;
+\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 2;\lsdpriority70 \lsdlocked0 Dark List Accent 2;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 2;\lsdpriority72 \lsdlocked0 Colorful List Accent 2;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 2;
+\lsdpriority60 \lsdlocked0 Light Shading Accent 3;\lsdpriority61 \lsdlocked0 Light List Accent 3;\lsdpriority62 \lsdlocked0 Light Grid Accent 3;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 3;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 3;
+\lsdpriority65 \lsdlocked0 Medium List 1 Accent 3;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 3;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 3;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 3;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 3;
+\lsdpriority70 \lsdlocked0 Dark List Accent 3;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 3;\lsdpriority72 \lsdlocked0 Colorful List Accent 3;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 3;\lsdpriority60 \lsdlocked0 Light Shading Accent 4;
+\lsdpriority61 \lsdlocked0 Light List Accent 4;\lsdpriority62 \lsdlocked0 Light Grid Accent 4;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 4;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 4;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 4;
+\lsdpriority66 \lsdlocked0 Medium List 2 Accent 4;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 4;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 4;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 4;\lsdpriority70 \lsdlocked0 Dark List Accent 4;
+\lsdpriority71 \lsdlocked0 Colorful Shading Accent 4;\lsdpriority72 \lsdlocked0 Colorful List Accent 4;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 4;\lsdpriority60 \lsdlocked0 Light Shading Accent 5;\lsdpriority61 \lsdlocked0 Light List Accent 5;
+\lsdpriority62 \lsdlocked0 Light Grid Accent 5;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 5;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 5;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 5;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 5;
+\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 5;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 5;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 5;\lsdpriority70 \lsdlocked0 Dark List Accent 5;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 5;
+\lsdpriority72 \lsdlocked0 Colorful List Accent 5;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 5;\lsdpriority60 \lsdlocked0 Light Shading Accent 6;\lsdpriority61 \lsdlocked0 Light List Accent 6;\lsdpriority62 \lsdlocked0 Light Grid Accent 6;
+\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 6;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 6;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 6;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 6;
+\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 6;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 6;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 6;\lsdpriority70 \lsdlocked0 Dark List Accent 6;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 6;
+\lsdpriority72 \lsdlocked0 Colorful List Accent 6;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 6;\lsdqformat1 \lsdpriority19 \lsdlocked0 Subtle Emphasis;\lsdqformat1 \lsdpriority21 \lsdlocked0 Intense Emphasis;
+\lsdqformat1 \lsdpriority31 \lsdlocked0 Subtle Reference;\lsdqformat1 \lsdpriority32 \lsdlocked0 Intense Reference;\lsdqformat1 \lsdpriority33 \lsdlocked0 Book Title;\lsdsemihidden1 \lsdunhideused1 \lsdpriority37 \lsdlocked0 Bibliography;
+\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority39 \lsdlocked0 TOC Heading;\lsdpriority41 \lsdlocked0 Plain Table 1;\lsdpriority42 \lsdlocked0 Plain Table 2;\lsdpriority43 \lsdlocked0 Plain Table 3;\lsdpriority44 \lsdlocked0 Plain Table 4;
+\lsdpriority45 \lsdlocked0 Plain Table 5;\lsdpriority40 \lsdlocked0 Grid Table Light;\lsdpriority46 \lsdlocked0 Grid Table 1 Light;\lsdpriority47 \lsdlocked0 Grid Table 2;\lsdpriority48 \lsdlocked0 Grid Table 3;\lsdpriority49 \lsdlocked0 Grid Table 4;
+\lsdpriority50 \lsdlocked0 Grid Table 5 Dark;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 1;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 1;
+\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 1;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 1;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 1;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 1;
+\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 1;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 2;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 2;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 2;
+\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 2;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 2;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 2;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 2;
+\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 3;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 3;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 3;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 3;
+\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 3;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 3;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 3;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 4;
+\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 4;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 4;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 4;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 4;
+\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 4;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 5;
+\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 5;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 5;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 5;
+\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 5;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 6;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 6;
+\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 6;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 6;
+\lsdpriority46 \lsdlocked0 List Table 1 Light;\lsdpriority47 \lsdlocked0 List Table 2;\lsdpriority48 \lsdlocked0 List Table 3;\lsdpriority49 \lsdlocked0 List Table 4;\lsdpriority50 \lsdlocked0 List Table 5 Dark;
+\lsdpriority51 \lsdlocked0 List Table 6 Colorful;\lsdpriority52 \lsdlocked0 List Table 7 Colorful;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 1;\lsdpriority47 \lsdlocked0 List Table 2 Accent 1;\lsdpriority48 \lsdlocked0 List Table 3 Accent 1;
+\lsdpriority49 \lsdlocked0 List Table 4 Accent 1;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 1;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 1;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 1;
+\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 2;\lsdpriority47 \lsdlocked0 List Table 2 Accent 2;\lsdpriority48 \lsdlocked0 List Table 3 Accent 2;\lsdpriority49 \lsdlocked0 List Table 4 Accent 2;
+\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 2;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 2;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 2;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 3;
+\lsdpriority47 \lsdlocked0 List Table 2 Accent 3;\lsdpriority48 \lsdlocked0 List Table 3 Accent 3;\lsdpriority49 \lsdlocked0 List Table 4 Accent 3;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 3;
+\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 3;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 3;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 4;\lsdpriority47 \lsdlocked0 List Table 2 Accent 4;
+\lsdpriority48 \lsdlocked0 List Table 3 Accent 4;\lsdpriority49 \lsdlocked0 List Table 4 Accent 4;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 4;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 4;
+\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 List Table 2 Accent 5;\lsdpriority48 \lsdlocked0 List Table 3 Accent 5;
+\lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
+\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
+\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;}}{\*\datastore 010500000200000018000000
+4d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
+d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000e063
+2d30deffd301feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
+000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000105000000000000}}

--- a/src/DLL/format.c
+++ b/src/DLL/format.c
@@ -68,7 +68,7 @@ void InitFormat(const wchar_t* section, SYSTEMTIME* lt)   //--------------------
 /*------------------------------------------------------------------------
 // Add Seconds to System Time
 //-----------------------------------------------------------------------*/
-void iAddSecondsToSystemTime(SYSTEMTIME* timeIn, double tfSeconds)
+void iAddSecondsToSystemTime(SYSTEMTIME* timeIn, long tfSeconds)
 {
 	FILETIME ft;
 


### PR DESCRIPTION
Added support for offset option which can be used to display multiple timezones.

Date / Time Offset
o ± x	= Changes the current time ± x given minutes. 
Can be used to display multiple timezone information with full support of other Formatting options. Anytime the format encounters ‘o±x’ pattern, the succeeding format pattern works on the offset time.

For example, if your system is set for India Standard Time, and you want to also see the time for Central Standard Time (10h 30m = 630m behind IST), you can specify
"IST:" hh:nn:ss tt "CST:"o-630hh:nn:ss tt
anything after the ‘o-630’ will use the offset time to be displayed.

We can have multiple offsets to show more timezones. Note that we will need to calculate the offset from the last offset time.

We can get it to look like
![image](https://user-images.githubusercontent.com/40093322/41190750-23c7f45e-6c02-11e8-9865-2c163f5508b4.png)
using the format string:
"IST"\nhh:nn:ss tt\nddd, dd mmm yyyy\n\n"CST"\no-630hh:nn:ss tt\nddd, dd mmm yyyy\n